### PR TITLE
add a "preview_emotion" query for Portraits

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -265,6 +265,40 @@ impl<'a> MonsterFormPortraits<'a> {
         })
     }
 
+    #[graphql(
+        description = "A single portrait. Return the 'Normal' portrait if avalaible, but may return another one if not present."
+    )]
+    fn preview_emotion(&self, context: &Context) -> Option<Portrait> {
+        if let Some(locked) = self.0.portrait_files.get("Normal") {
+            Some(Portrait {
+                emotion: "Normal".to_string(),
+                locked: *locked,
+                url: get_url(
+                    AssetType::Portrait("Normal"),
+                    &context.this_server_url,
+                    self.1,
+                    self.2,
+                ),
+            })
+        } else {
+            self.0
+                .portrait_files
+                .iter()
+                .sorted()
+                .next()
+                .map(|(emotion, locked)| Portrait {
+                    emotion: emotion.clone(),
+                    locked: *locked,
+                    url: get_url(
+                        AssetType::Portrait(emotion),
+                        &context.this_server_url,
+                        self.1,
+                        self.2,
+                    ),
+                })
+        }
+    }
+
     #[graphql(description = "A list of all existing flipped portraits for the emotions.")]
     fn emotions_flipped(&self, context: &Context) -> Vec<Portrait> {
         self.0


### PR DESCRIPTION
On NotSpriteCollab, there is a sprite which only have the "Angry" emotion. The client could then just call this path/query/whatever it's named (have yet to learn graphql) instead of emotion("Normal").