### PR TITLE
Shallow clone sprite repo

### DIFF
--- a/src/sprite_collab.rs
+++ b/src/sprite_collab.rs
@@ -13,8 +13,8 @@ use async_trait::async_trait;
 use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 use fred::prelude::{ClientLike, KeysInterface, ReconnectPolicy};
 use fred::types::Key;
-use git2::build::CheckoutBuilder;
-use git2::{Repository, ResetType};
+use git2::build::{CheckoutBuilder, RepoBuilder};
+use git2::{FetchOptions, Repository, ResetType};
 use log::{debug, error, info, warn};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -374,7 +374,14 @@ fn try_update_repo(path: &Path) -> Result<Repository, Error> {
 
 fn create_repo(path: &Path, clone_url: &str) -> Result<Repository, Error> {
     info!("Cloning SpriteCollab repo...");
-    let repo = Repository::clone(clone_url, path)?;
+    
+    // Use FetchOptions to enable shallow cloning (the repo is too big to handle otherwise)
+    let mut fo = FetchOptions::new();
+    fo.depth(1);
+    let mut builder = RepoBuilder::new();
+    builder.fetch_options(fo);
+    
+    let repo = builder.clone(clone_url, path)?;
     info!("Cloning SpriteCollab repo. Done!");
     Ok(repo)
 }


### PR DESCRIPTION
Cloning the whole sprite repository, including its history, is starting to cause performance issues due to how big it's getting. This PR switches cloning mode to shallow cloning, which excludes past history. It shouldn't affect the data shown on the website, since old versions aren't viewable there anyway, and credit history is extracted from the credit.txt files, which always contain the whole history in the latest branch.

Newly added commits would simply get added on top of the shallow copy. As long as the remote doesn't overwrite history before the last shallow clone point, we shouldn't run into problems there.

Note that I don't know Rust, I managed to stitch the changes together by reading documentation on the git2 library (namely, the [RepoBuilder](https://docs.rs/git2/0.20.0/git2/build/struct.RepoBuilder.html) and [FetchOptions](https://docs.rs/git2/0.20.0/git2/struct.FetchOptions.html) pages). I'd appreciate if someone with more knowledge than me could double-check the code.